### PR TITLE
Add BOM and DNP exclusions

### DIFF
--- a/SparkFunKiCadBOMGenerator/plugin.py
+++ b/SparkFunKiCadBOMGenerator/plugin.py
@@ -69,6 +69,8 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
             for footprint in self.unwanted_footprints: # Check for KiBuzzard etc.
                 if footprint in pack:
                     unwanted = True
+            if sourceModule.IsExcludedFromBOM():
+                unwanted = True
             if not unwanted:
                 ref = sourceModule.Reference().GetText()
                 val = sourceModule.Value().GetText()
@@ -98,7 +100,7 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
                         if not head_tail[1].isnumeric():
                             prod_id = ">> INVALID <<"
                 uniqueRef = name + val + prod_id
-                if hasProdID:
+                if hasProdID and not sourceModule.IsDNP():
                     if "EMPTY" not in prod_id and "INVALID" not in prod_id:
                         prodIdNum = prod_id.split("-")[1]
                         while prodIdNum[0] == "0":


### PR DESCRIPTION
Add ability to exclude FP from BOM using "Exclude from Bill of Materials" checkbox FP attribute. FP will **not** show up in Non-BOM Items list.

Add ability to DNP a FP by checking "Do not Populate" checkbox FP attribute. FP will show up in Non-BOM Items list.

I have tested this successfully. Exclude pre-empts DNP.

Exclude is useful for things such as a board outline footprint.

DNP is useful for... well, DNPs.