### PR TITLE
Fixes version testing and field capture in KiCad 10

### DIFF
--- a/SparkFunKiCadBOMGenerator/plugin.py
+++ b/SparkFunKiCadBOMGenerator/plugin.py
@@ -36,9 +36,9 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
 
         self._pcbnew_frame = None
 
-        self.baseVersion = pcbnew.GetBuildVersion().split(".")[
-            0
-        ]  # Use GetBuildVersion. GetBaseVersion is only available in KiCad 8
+        self.baseVersion = int(
+            pcbnew.GetBuildVersion().split(".")[0]
+        )  # Use GetBuildVersion. GetBaseVersion is only available in KiCad 8
 
     def Run(self):
         if self._pcbnew_frame is None:
@@ -89,18 +89,22 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
                     name = name.split(":")[1]
                 prod_id = ""
                 hasProdID = False
-                if self.baseVersion < "8":
+                if self.baseVersion < 8:
                     if hasattr(sourceModule, "HasProperty"):
                         if sourceModule.HasProperty("PROD_ID"):
                             prod_id = sourceModule.GetPropertyNative("PROD_ID")
                             hasProdID = True
-                else:
+                if self.baseVersion == 9:
                     if sourceModule.HasFieldByName(
                         "PROD_ID"
                     ):  # Breaking change for KiCad 8
                         prod_id = sourceModule.GetFieldText(
                             "PROD_ID"
                         )  # Breaking change for KiCad 8
+                        hasProdID = True
+                else:
+                    if sourceModule.HasField("PROD_ID"):
+                        prod_id = sourceModule.GetField("PROD_ID").GetText()
                         hasProdID = True
                 if hasProdID:
                     if prod_id == "":
@@ -115,7 +119,7 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
                             prod_id = ">> INVALID <<"
                 uniqueRef = name + val + prod_id
                 DNP = False
-                if self.baseVersion >= "8":
+                if self.baseVersion >= 8:
                     DNP = sourceModule.IsDNP()
                 if hasProdID and not DNP:
                     if "EMPTY" not in prod_id and "INVALID" not in prod_id:
@@ -220,4 +224,3 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
 
         finally:
             dlg.Destroy()
-

--- a/SparkFunKiCadBOMGenerator/plugin.py
+++ b/SparkFunKiCadBOMGenerator/plugin.py
@@ -6,22 +6,22 @@ import pcbnew
 
 from .dialog import Dialog
 
-class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
 
+class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
     # Don't include footprints from these libraries
-    unwanted_libraries = ['SparkFun-Jumper', 'SparkFun-Aesthetic']
+    unwanted_libraries = ["SparkFun-Jumper", "SparkFun-Aesthetic"]
 
     # Don't include these footprints
-    unwanted_footprints = ['kibuzzard', 'STANDOFF']
+    unwanted_footprints = ["kibuzzard", "STANDOFF"]
 
     # SparkFun panelizer fiducials are from KiCad Fiducial.pretty: Fiducial_1.5mm_Mask3mm
     fid_name = "Fiducial_1.5mm_Mask3mm"
 
     # All dimension parameters used by this script are um unless otherwise noted
     # KiCad works in nm (integer)
-    SCALE_MM = 1000000 # Convert mm to nm
-    SCALE_UM = 1000 # Convert um to nm
-    SCALE_MD = 1000 # Convert degrees to microdegrees
+    SCALE_MM = 1000000  # Convert mm to nm
+    SCALE_UM = 1000  # Convert um to nm
+    SCALE_MD = 1000  # Convert degrees to microdegrees
 
     def __init__(self):
         super(BomGeneratorPlugin, self).__init__()
@@ -31,17 +31,27 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
         self.pcbnew_icon_support = hasattr(self, "show_toolbar_button")
         self.show_toolbar_button = True
         icon_dir = os.path.dirname(__file__)
-        self.icon_file_name = os.path.join(icon_dir, 'icon.png')
+        self.icon_file_name = os.path.join(icon_dir, "icon.png")
         self.description = "Generate SparkFun BOM"
-        
+
         self._pcbnew_frame = None
 
-        self.baseVersion = pcbnew.GetBuildVersion().split('.')[0] # Use GetBuildVersion. GetBaseVersion is only available in KiCad 8
+        self.baseVersion = pcbnew.GetBuildVersion().split(".")[
+            0
+        ]  # Use GetBuildVersion. GetBaseVersion is only available in KiCad 8
 
     def Run(self):
         if self._pcbnew_frame is None:
             try:
-                self._pcbnew_frame = [x for x in wx.GetTopLevelWindows() if ('pcbnew' in x.GetTitle().lower() and not 'python' in x.GetTitle().lower()) or ('pcb editor' in x.GetTitle().lower())]
+                self._pcbnew_frame = [
+                    x
+                    for x in wx.GetTopLevelWindows()
+                    if (
+                        "pcbnew" in x.GetTitle().lower()
+                        and not "python" in x.GetTitle().lower()
+                    )
+                    or ("pcb editor" in x.GetTitle().lower())
+                ]
                 if len(self._pcbnew_frame) == 1:
                     self._pcbnew_frame = self._pcbnew_frame[0]
                 else:
@@ -63,10 +73,10 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
             # E.g.: SparkFun-Semiconductor-Standard:TSSOP-16
             pack = sourceModule.GetFPIDAsString()
             unwanted = False
-            for lib in self.unwanted_libraries: # Check for aesthetics etc.
+            for lib in self.unwanted_libraries:  # Check for aesthetics etc.
                 if lib in pack:
                     unwanted = True
-            for footprint in self.unwanted_footprints: # Check for KiBuzzard etc.
+            for footprint in self.unwanted_footprints:  # Check for KiBuzzard etc.
                 if footprint in pack:
                     unwanted = True
             if sourceModule.IsExcludedFromBOM():
@@ -79,14 +89,18 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
                     name = name.split(":")[1]
                 prod_id = ""
                 hasProdID = False
-                if self.baseVersion < '8':
+                if self.baseVersion < "8":
                     if hasattr(sourceModule, "HasProperty"):
                         if sourceModule.HasProperty("PROD_ID"):
                             prod_id = sourceModule.GetPropertyNative("PROD_ID")
                             hasProdID = True
                 else:
-                    if sourceModule.HasFieldByName("PROD_ID"): # Breaking change for KiCad 8
-                        prod_id = sourceModule.GetFieldText("PROD_ID") # Breaking change for KiCad 8
+                    if sourceModule.HasFieldByName(
+                        "PROD_ID"
+                    ):  # Breaking change for KiCad 8
+                        prod_id = sourceModule.GetFieldText(
+                            "PROD_ID"
+                        )  # Breaking change for KiCad 8
                         hasProdID = True
                 if hasProdID:
                     if prod_id == "":
@@ -101,7 +115,7 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
                             prod_id = ">> INVALID <<"
                 uniqueRef = name + val + prod_id
                 DNP = False
-                if self.baseVersion >= '8':
+                if self.baseVersion >= "8":
                     DNP = sourceModule.IsDNP()
                 if hasProdID and not DNP:
                     if "EMPTY" not in prod_id and "INVALID" not in prod_id:
@@ -113,67 +127,78 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
                         else:
                             sparkleBom = sparkleBom + "," + prodIdNum
                     if uniqueRef in bom_items.keys():
-                        bom_items[uniqueRef]['Qty'] = bom_items[uniqueRef]['Qty'] + 1
-                        if ref not in bom_items[uniqueRef]['Refs'].split(","): # Avoid duplicate refs
-                            bom_items[uniqueRef]['Refs'] = bom_items[uniqueRef]['Refs'] + "," + ref
+                        bom_items[uniqueRef]["Qty"] = bom_items[uniqueRef]["Qty"] + 1
+                        if ref not in bom_items[uniqueRef]["Refs"].split(
+                            ","
+                        ):  # Avoid duplicate refs
+                            bom_items[uniqueRef]["Refs"] = (
+                                bom_items[uniqueRef]["Refs"] + "," + ref
+                            )
                     else:
-                        bom_items.setdefault(uniqueRef,
-                                            {
-                                                'Qty': None,
-                                                'PROD_ID': None,
-                                                'Refs': None,
-                                                'Value': None,
-                                                'Package': None
-                                            })
-                        bom_items[uniqueRef]['Qty'] = 1
-                        bom_items[uniqueRef]['PROD_ID'] = prod_id
-                        bom_items[uniqueRef]['Refs'] = ref
-                        bom_items[uniqueRef]['Value'] = val
-                        bom_items[uniqueRef]['Package'] = name
+                        bom_items.setdefault(
+                            uniqueRef,
+                            {
+                                "Qty": None,
+                                "PROD_ID": None,
+                                "Refs": None,
+                                "Value": None,
+                                "Package": None,
+                            },
+                        )
+                        bom_items[uniqueRef]["Qty"] = 1
+                        bom_items[uniqueRef]["PROD_ID"] = prod_id
+                        bom_items[uniqueRef]["Refs"] = ref
+                        bom_items[uniqueRef]["Value"] = val
+                        bom_items[uniqueRef]["Package"] = name
                 else:
                     if uniqueRef in non_bom_items.keys():
-                        non_bom_items[uniqueRef]['Qty'] = non_bom_items[uniqueRef]['Qty'] + 1
-                        if ref not in non_bom_items[uniqueRef]['Refs'].split(","): # Avoid duplicate refs
-                            non_bom_items[uniqueRef]['Refs'] = non_bom_items[uniqueRef]['Refs'] + "," + ref
+                        non_bom_items[uniqueRef]["Qty"] = (
+                            non_bom_items[uniqueRef]["Qty"] + 1
+                        )
+                        if ref not in non_bom_items[uniqueRef]["Refs"].split(
+                            ","
+                        ):  # Avoid duplicate refs
+                            non_bom_items[uniqueRef]["Refs"] = (
+                                non_bom_items[uniqueRef]["Refs"] + "," + ref
+                            )
                     else:
-                        non_bom_items.setdefault(uniqueRef,
-                                            {
-                                                'Qty': None,
-                                                'Refs': None,
-                                                'Value': None,
-                                                'Package': None
-                                            })
-                        non_bom_items[uniqueRef]['Qty'] = 1
-                        non_bom_items[uniqueRef]['Refs'] = ref
-                        non_bom_items[uniqueRef]['Value'] = val
-                        non_bom_items[uniqueRef]['Package'] = name
+                        non_bom_items.setdefault(
+                            uniqueRef,
+                            {"Qty": None, "Refs": None, "Value": None, "Package": None},
+                        )
+                        non_bom_items[uniqueRef]["Qty"] = 1
+                        non_bom_items[uniqueRef]["Refs"] = ref
+                        non_bom_items[uniqueRef]["Value"] = val
+                        non_bom_items[uniqueRef]["Package"] = name
 
         # Copy bom_items into grid
         empty_invalid = False
-        dlg.bomGrid.CreateGrid( 0, 5 )
+        dlg.bomGrid.CreateGrid(0, 5)
         dlg.bomGrid.AppendRows(len(bom_items.keys()))
         dlg.bomGrid.SetBackgroundStyle(wx.SOLID)
         row = 0
         for name in bom_items.keys():
-            dlg.bomGrid.SetCellValue(row, 0, str(bom_items[name]['Qty']))
-            dlg.bomGrid.SetCellValue(row, 1, str(bom_items[name]['PROD_ID']))
-            if ("EMPTY" in bom_items[name]['PROD_ID']) or ("INVALID" in bom_items[name]['PROD_ID']):
+            dlg.bomGrid.SetCellValue(row, 0, str(bom_items[name]["Qty"]))
+            dlg.bomGrid.SetCellValue(row, 1, str(bom_items[name]["PROD_ID"]))
+            if ("EMPTY" in bom_items[name]["PROD_ID"]) or (
+                "INVALID" in bom_items[name]["PROD_ID"]
+            ):
                 dlg.bomGrid.SetCellBackgroundColour(row, 1, wx.RED)
                 empty_invalid = True
-            dlg.bomGrid.SetCellValue(row, 2, str(bom_items[name]['Refs']))
-            dlg.bomGrid.SetCellValue(row, 3, str(bom_items[name]['Value']))
-            dlg.bomGrid.SetCellValue(row, 4, str(bom_items[name]['Package']))
+            dlg.bomGrid.SetCellValue(row, 2, str(bom_items[name]["Refs"]))
+            dlg.bomGrid.SetCellValue(row, 3, str(bom_items[name]["Value"]))
+            dlg.bomGrid.SetCellValue(row, 4, str(bom_items[name]["Package"]))
             row += 1
 
         # Copy non_bom_items into grid
-        dlg.nonBomGrid.CreateGrid( 0, 4 )
+        dlg.nonBomGrid.CreateGrid(0, 4)
         dlg.nonBomGrid.AppendRows(len(non_bom_items.keys()))
         row = 0
         for name in non_bom_items.keys():
-            dlg.nonBomGrid.SetCellValue(row, 0, str(non_bom_items[name]['Qty']))
-            dlg.nonBomGrid.SetCellValue(row, 1, str(non_bom_items[name]['Refs']))
-            dlg.nonBomGrid.SetCellValue(row, 2, str(non_bom_items[name]['Value']))
-            dlg.nonBomGrid.SetCellValue(row, 3, str(non_bom_items[name]['Package']))
+            dlg.nonBomGrid.SetCellValue(row, 0, str(non_bom_items[name]["Qty"]))
+            dlg.nonBomGrid.SetCellValue(row, 1, str(non_bom_items[name]["Refs"]))
+            dlg.nonBomGrid.SetCellValue(row, 2, str(non_bom_items[name]["Value"]))
+            dlg.nonBomGrid.SetCellValue(row, 3, str(non_bom_items[name]["Package"]))
             row += 1
 
         # Copy Sparkle BOM into TextCrtl
@@ -185,13 +210,14 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
 
         try:
             if empty_invalid:
-                wx.MessageBox("EMPTY or INVALID PROD_IDs found!\nCheck BOM Items for details.",
-                            'Error', wx.OK | wx.ICON_ERROR)
+                wx.MessageBox(
+                    "EMPTY or INVALID PROD_IDs found!\nCheck BOM Items for details.",
+                    "Error",
+                    wx.OK | wx.ICON_ERROR,
+                )
 
             dlg.ShowModal()
-            
+
         finally:
             dlg.Destroy()
-                        
 
-    

--- a/SparkFunKiCadBOMGenerator/plugin.py
+++ b/SparkFunKiCadBOMGenerator/plugin.py
@@ -94,7 +94,7 @@ class BomGeneratorPlugin(pcbnew.ActionPlugin, object):
                         if sourceModule.HasProperty("PROD_ID"):
                             prod_id = sourceModule.GetPropertyNative("PROD_ID")
                             hasProdID = True
-                if self.baseVersion == 9:
+                elif self.baseVersion == 9:
                     if sourceModule.HasFieldByName(
                         "PROD_ID"
                     ):  # Breaking change for KiCad 8


### PR DESCRIPTION
This fixes the version check in the script. In KiCad 10 - the version check returned true because "10" was less then "8" because the "1" in "10" is less than "8". Casting it as an integer fixes that issue. 

Secondly, the function call that checks fields changed again:  `HasProperty` to `HasFieldByName` to `HasField` in Kicad 8/9/10 respectively. 

With these two changes in place, the BOM generator works (at least in 10). I have not tested this in older versions but I don't suspect that casting the initial version check as integer would have any negative affect.

Let me know if I've missed anything, or you would like me to add something. 